### PR TITLE
Update repo.json

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -7,7 +7,7 @@
       "TestingAssemblyVersion": "1.0.0",
       "Description": "Allows you to export your character as a MCDF File.",
       "ApplicableVersion": "any",
-      "RepoUrl": "https://github.com/CNanaKhide/MCDExport",
+      "RepoUrl": "https://github.com/NanaKhide/MCDExport",
       "Tags": ["gpose", "utility", "tools"],
       "DownloadLinkInstall": "https://github.com/NanaKhide/MCDExport/releases/download/v1.0.0/MCDExport.zip",
       "DownloadLinkTesting": "https://github.com/NanaKhide/MCDExport/releases/download/v1.0.0/MCDExport.zip",


### PR DESCRIPTION
Fixed typo on line 10 regarding RepoURL, as trying to visit the plugin URL leads to an Error 404 page.

<img width="404" height="209" alt="image" src="https://github.com/user-attachments/assets/712efb98-0a88-4ab6-a95e-dbe1dbcb0164" />

<img width="902" height="332" alt="image" src="https://github.com/user-attachments/assets/7b02c90e-53ab-459c-8799-9e0ec7bd77cc" />
